### PR TITLE
Avoid crash on initial load of history-less scenes

### DIFF
--- a/src/classes/MaskLayer.js
+++ b/src/classes/MaskLayer.js
@@ -294,6 +294,7 @@ export default class MaskLayer extends InteractionLayer {
 		isInit = false
 	) {
 		simplefogLogDebug("MaskLayer.renderStack");
+		history = history || { events: [], pointer: 0 };
 		// If history is blank, do nothing
 		if (history === undefined && !isInit) {
 			simplefogLogDebug("MaskLayer.renderStack - set visible to autoEnableSceneFog");

--- a/src/module.json
+++ b/src/module.json
@@ -47,6 +47,17 @@
 			"ko-fi": "",
 			"reddit": "",
 			"email": ""
+		},
+		{
+			"name": "cirrahn",
+			"url": "https://github.com/cirrahn",
+			"discord": "",
+			"twitter": "",
+			"patreon": "cirrahn",
+			"github": "cirrahn",
+			"ko-fi": "",
+			"reddit": "",
+			"email": ""
 		}
 	],
 	"type": "module",


### PR DESCRIPTION
This squashes a common, junk error when loading a scene which does not have simplefog flags set (e.g. a scene created before the module was activated).

Closes #102

Closes #103